### PR TITLE
Split added test case so we can see both failures.

### DIFF
--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -39,6 +39,8 @@ def test_unicode_params():
     )
     eq_(res, b"SELECT * FROM \xce\x94 WHERE name = N'\xce\xa8'")
 
+
+def test_unicode_params2():
     res = substitute_params(u"testing ascii (\u0105\u010D\u0119) 1=%d 'one'=%s", (1, u'str'))
     eq_(res, b"testing ascii (\xc4\x85\xc4\x8d\xc4\x99) 1=1 'one'=N'str'")
 


### PR DESCRIPTION
Bill,

I'm seeing the following failures when running tests with Python 2.7 and SQL Server 2008:

```
$ py.test tests/test_utils.py
*** 1450566424: Grabbing app lock for pymssql tests
*** 1450566424: sp_getapplock for 'pymssql_tests' returned 0 - it took 0 seconds
=================================================================================== test session starts ====================================================================================
platform linux2 -- Python 2.7.6 -- py-1.4.26 -- pytest-2.7.0
rootdir: /home/ramiro/.virtualenvs/pymssql/src/pymssql, inifile: pytest.ini
collected 17 items 

tests/test_utils.py ..FF.F...........

========================================================================================= FAILURES =========================================================================================
___________________________________________________________________________________ test_unicode_params ____________________________________________________________________________________
tests/test_utils.py:40: in test_unicode_params
    eq_(res, b"SELECT * FROM \xce\x94 WHERE name = N'\xce\xa8'")
tests/helpers.py:8: in eq_
    assert a == b
E   assert "SELECT * FRO...=N'\xce\xa8's" == "SELECT * FROM...= N'\xce\xa8'"
E     - SELECT * FROM \xce\x94 WHERE name =N'\xce\xa8's
E     ?                                               -
E     + SELECT * FROM \xce\x94 WHERE name = N'\xce\xa8'
E     ?                                    +
___________________________________________________________________________________ test_unicode_params2 ___________________________________________________________________________________
tests/test_utils.py:45: in test_unicode_params2
    eq_(res, b"testing ascii (\xc4\x85\xc4\x8d\xc4\x99) 1=1 'one'=N'str'")
tests/helpers.py:8: in eq_
    assert a == b
E   assert "testing asci... 'onN'str'=%%s" == "testing ascii... 'one'=N'str'"
E     - testing ascii (\xc4\x85\xc4\x8d\xc4\x99)1=%%d 'onN'str'=%%s
E     ?                                           ^^          ---
E     + testing ascii (\xc4\x85\xc4\x8d\xc4\x99) 1=1 'one'=N'str'
E     ?                                         +  ^    +++
_________________________________________________________________________________ test_keyed_param_with_d __________________________________________________________________________________
tests/test_utils.py:59: in test_keyed_param_with_d
    eq_(res, b'SELECT * FROM employees WHERE id = 13')
tests/helpers.py:8: in eq_
    assert a == b
E   assert 'SELECT * FRO... = %%(emp_id)d' == 'SELECT * FROM...WHERE id = 13'
E     - SELECT * FROM employees WHERE id = %%(emp_id)d
E     ?                                    ^^^^^^^^^^
E     + SELECT * FROM employees WHERE id = 13
E     ?                                    ^^
================================================================================= short test summary info ==================================================================================
FAIL tests/test_utils.py::test_unicode_params
FAIL tests/test_utils.py::test_unicode_params2
FAIL tests/test_utils.py::test_keyed_param_with_d
=========================================================================== 3 failed, 14 passed in 0.08 seconds ============================================================================
*** 1450566426: sp_releaseapplock for 'pymssql_tests' returned 0
```

At first I believed the conflict with your fix for #291 had something to do but further examination shows there is still some problem with tracking of the offset through the string.
